### PR TITLE
switches to initial login view on logout after storyboard split

### DIFF
--- a/PetPals/Profile/UserProfile.swift
+++ b/PetPals/Profile/UserProfile.swift
@@ -133,8 +133,7 @@ class UserProfile: NSObject {
     class func logOutUser(completion: @escaping (NSError?) -> Swift.Void) {
         do {
             try Auth.auth().signOut()
-            
-            let storyBoard : UIStoryboard = UIStoryboard(name: "Main", bundle:nil)
+            let storyBoard : UIStoryboard = UIStoryboard(name: "Initial", bundle:nil)
             let appdelegate = UIApplication.shared.delegate as! AppDelegate
             appdelegate.window!.rootViewController = storyBoard.instantiateInitialViewController()
             


### PR DESCRIPTION
After splitting the storyboards there was an error logging out this fixes that to switch to the right VC after successful logout